### PR TITLE
remove MultilineMethodCallIndentation and upgrade rubocop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -7,7 +7,7 @@ inherit_mode:
 Rails:
   Enabled: true
 AllCops:
-  TargetRubyVersion: 3.1.2
+  TargetRubyVersion: 3.2
   NewCops: enable
   SuggestExtensions: false
 
@@ -27,8 +27,6 @@ Layout/EmptyLinesAroundModuleBody:
   EnforcedStyle: empty_lines_except_namespace
 Layout/LineLength:
   Enabled: false
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented_relative_to_receiver
 
 Lint/SuppressedException:
   AllowComments: true

--- a/easy_style.gemspec
+++ b/easy_style.gemspec
@@ -10,9 +10,8 @@ Gem::Specification.new do |spec|
   spec.description   = "Rubocop configs"
   spec.homepage      = "https://github.com/easysoftware/easy_style"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 3.1.2"
+  spec.required_ruby_version = ">= 3.2"
 
-  # spec.metadata['allowed_push_host'] = 'TODO: Set to \'http://mygemserver.com\''
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
@@ -27,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.60.0"
-  spec.add_dependency "rubocop-rails", "~> 2.23.1"
+  spec.add_dependency "rubocop", "~> 1.73"
+  spec.add_dependency "rubocop-rails", "~> 2.30"
 end

--- a/lib/easy_style/version.rb
+++ b/lib/easy_style/version.rb
@@ -1,5 +1,5 @@
 module EasyStyle
 
-  VERSION = "0.6.2"
+  VERSION = "0.7.0"
 
 end


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/cops_layout.html#layoutmultilinemethodcallindentation

in RubyMine we are using default 

```.editorconfig
[{*.gemspec,*.jbuilder,*.rake,*.rb,*.erb,*.ru,*.thor,.simplecov,capfile,gemfile,Gemfile,rakefile}]
ij_ruby_chain_calls_alignment = 2
```

So rubocop default`aligned` is what we want