### PR TITLE
Current ER/EP tolarate 3.1.2 for some reasons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    easy_style (0.7.0)
+    easy_style (0.7.1)
       rubocop (~> 1.73)
       rubocop-rails (~> 2.30)
 
@@ -67,6 +67,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux

--- a/easy_style.gemspec
+++ b/easy_style.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Rubocop configs"
   spec.homepage      = "https://github.com/easysoftware/easy_style"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.1.2"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/lib/easy_style/version.rb
+++ b/lib/easy_style/version.rb
@@ -1,5 +1,5 @@
 module EasyStyle
 
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 
 end


### PR DESCRIPTION
ER/EP v14.5.x officially support only ruby 3.3.7, but there is possibility by code to tolerate 3.1.2. I do not want manage ruby version main product by this gem.